### PR TITLE
Display Flags and Text in Examples/Solutions Gallery permanently

### DIFF
--- a/css/3-col-portfolio.css
+++ b/css/3-col-portfolio.css
@@ -67,16 +67,11 @@ footer {
 }
 
 .gallery-meta {
-    visibility: hidden;
     display:table;
     position: relative;
     display: table;
     padding: 5px;
     width:100%;
-}
-
-.gallery-link:hover .gallery-meta {
-    visibility: visible;
 }
 
 .gallery-category {


### PR DESCRIPTION
This PR fixes the misinterpretation of #3 for only displaying the country flags and text when hovering over a particular image.

With this CSS fix the flags and text will always show similar to the screenshot below:
<img width="1222" alt="screen shot 2016-12-01 at 5 14 58 pm" src="https://cloud.githubusercontent.com/assets/2396774/20814937/ba8a2322-b7e9-11e6-9ddd-7988a44a3314.png">
